### PR TITLE
feat(ISSUE-15): implement OpenAI photo/vision lookup

### DIFF
--- a/NutriFacts/Models/UIImage+Resize.swift
+++ b/NutriFacts/Models/UIImage+Resize.swift
@@ -1,0 +1,21 @@
+// UIImage+Resize.swift
+// NutriFacts
+
+import UIKit
+
+extension UIImage {
+    /// Returns a new image scaled so the longest side does not exceed `maxDimension` points.
+    /// If the image is already within the limit, returns `self` unchanged.
+    func resized(toMaxDimension maxDimension: CGFloat) -> UIImage {
+        let longestSide = max(size.width, size.height)
+        guard longestSide > maxDimension else { return self }
+
+        let scale = maxDimension / longestSide
+        let newSize = CGSize(width: (size.width * scale).rounded(), height: (size.height * scale).rounded())
+
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        return renderer.image { _ in
+            draw(in: CGRect(origin: .zero, size: newSize))
+        }
+    }
+}

--- a/NutriFacts/Services/NetworkSession.swift
+++ b/NutriFacts/Services/NetworkSession.swift
@@ -1,0 +1,11 @@
+// NetworkSession.swift
+// NutriFacts
+
+import Foundation
+
+/// Abstraction over URLSession to allow injecting mock sessions in tests.
+protocol NetworkSession {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: NetworkSession {}

--- a/NutriFacts/Services/OpenAIService.swift
+++ b/NutriFacts/Services/OpenAIService.swift
@@ -9,11 +9,11 @@ final class OpenAIService: AIServiceProtocol {
 
     private let requestBuilder: OpenAIRequestBuilder
     private let responseParser: OpenAIResponseParser
-    private let urlSession: URLSession
+    private let urlSession: NetworkSession
 
     init(
         apiKey: String = APIKeyProvider.openAIKey,
-        urlSession: URLSession = .shared
+        urlSession: NetworkSession = URLSession.shared
     ) {
         self.requestBuilder = OpenAIRequestBuilder(apiKey: apiKey)
         self.responseParser = OpenAIResponseParser()
@@ -28,7 +28,8 @@ final class OpenAIService: AIServiceProtocol {
     }
 
     func lookupNutrition(image: UIImage) async throws -> NutritionFacts {
-        guard let imageData = image.jpegData(compressionQuality: 0.8) else {
+        let resizedImage = image.resized(toMaxDimension: 1024)
+        guard let imageData = resizedImage.jpegData(compressionQuality: 0.8) else {
             throw AppError.invalidImage
         }
         let request = try requestBuilder.buildImageRequest(imageData: imageData)

--- a/NutriFactsTests/MockURLSession.swift
+++ b/NutriFactsTests/MockURLSession.swift
@@ -1,0 +1,26 @@
+// MockURLSession.swift
+// NutriFactsTests
+
+import Foundation
+@testable import NutriFacts
+
+/// A mock NetworkSession that returns pre-configured responses without network calls.
+final class MockNetworkSession: NetworkSession, @unchecked Sendable {
+    private let responseData: Data
+    private let statusCode: Int
+
+    init(responseData: Data, statusCode: Int = 200) {
+        self.responseData = responseData
+        self.statusCode = statusCode
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(string: "https://api.openai.com")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        return (responseData, response)
+    }
+}

--- a/NutriFactsTests/NutriFactsTests.swift
+++ b/NutriFactsTests/NutriFactsTests.swift
@@ -790,8 +790,10 @@ struct SpeechDictationTests {
             speechService: mockSpeech
         )
         await viewModel.startDictation()
-        // Yield to allow the background dictation task to consume the stream
-        await Task.yield()
+        // Yield multiple times to allow the background dictation task to consume the stream
+        for _ in 0..<10 {
+            await Task.yield()
+        }
         #expect(viewModel.searchText == "Banana")
     }
 
@@ -920,7 +922,65 @@ struct AppleIntelligenceServiceTests {
     }
 }
 
+// MARK: - OpenAI Vision / Image Tests
 
+@Suite("OpenAI Vision Service")
+@MainActor
+struct OpenAIVisionServiceTests {
+
+    private func makeSuccessJSON(productName: String = "Salmon") -> Data {
+        let jsonString = """
+        {
+          "choices": [{
+            "message": {
+              "content": "{\\"productName\\":\\"\(productName)\\",\\"isLiquid\\":false,\\"macronutrients\\":{\\"calories\\":208,\\"totalFat\\":13,\\"saturatedFat\\":3,\\"transFat\\":0,\\"carbohydrates\\":0,\\"sugar\\":0,\\"dietaryFiber\\":0,\\"protein\\":20},\\"vitamins\\":[],\\"minerals\\":[],\\"allergens\\":[],\\"ingredients\\":null}"
+            }
+          }]
+        }
+        """
+        return Data(jsonString.utf8)
+    }
+
+    @Test("resized image does not exceed max dimension")
+    func testUIImageResize_largeImage_reducesToMaxDimension() {
+        let largeSize = CGSize(width: 3000, height: 2000)
+        let renderer = UIGraphicsImageRenderer(size: largeSize)
+        let largeImage = renderer.image { context in
+            UIColor.red.setFill()
+            context.fill(CGRect(origin: .zero, size: largeSize))
+        }
+        let resized = largeImage.resized(toMaxDimension: 1024)
+        let maxDimension = max(resized.size.width, resized.size.height)
+        #expect(maxDimension <= 1024)
+    }
+
+    @Test("image request uses OpenAI endpoint URL")
+    func testLookupNutrition_image_callsVisionEndpoint() async throws {
+        let mockSession = MockNetworkSession(responseData: makeSuccessJSON())
+        let service = OpenAIService(apiKey: "test-key", urlSession: mockSession)
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 100, height: 100))
+        let image = renderer.image { context in
+            UIColor.blue.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 100, height: 100))
+        }
+        let result = try await service.lookupNutrition(image: image)
+        #expect(result.productName == "Salmon")
+    }
+
+    @Test("image lookup with valid response returns NutritionFacts")
+    func testLookupNutrition_image_validResponse_returnsNutritionFacts() async throws {
+        let mockSession = MockNetworkSession(responseData: makeSuccessJSON(productName: "Salmon"))
+        let service = OpenAIService(apiKey: "test-key", urlSession: mockSession)
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: 200, height: 200))
+        let image = renderer.image { context in
+            UIColor.green.setFill()
+            context.fill(CGRect(x: 0, y: 0, width: 200, height: 200))
+        }
+        let result = try await service.lookupNutrition(image: image)
+        #expect(result.productName == "Salmon")
+        #expect(result.macronutrients.calories == 208)
+    }
+}
 
 
 


### PR DESCRIPTION
## Summary
- Adds `UIImage+Resize.swift` with `resized(toMaxDimension:)` that scales images so the longest side ≤ the given limit (returns self if already within bounds)
- Wires the resize into `OpenAIService.lookupNutrition(image:)` before JPEG encoding — max 1024px before sending to GPT-4o
- Introduces `NetworkSession` protocol so tests can inject a `MockNetworkSession` without subclassing `URLSession`

## Changes
| File | Change |
|---|---|
| `UIImage+Resize.swift` | New extension: `resized(toMaxDimension:)` |
| `OpenAIService.swift` | Resize image before encoding; depend on `NetworkSession` protocol |
| `NetworkSession.swift` | New protocol + `URLSession` conformance |
| `MockURLSession.swift` | `MockNetworkSession` for test injection |
| `NutriFactsTests.swift` | `OpenAIVisionServiceTests` (3 new tests); fix dictation test flakiness |

## Test plan
- [x] All 61 unit tests pass
- [x] `testUIImageResize_largeImage_reducesToMaxDimension` — 3000×2000 image resized to max 1024
- [x] `testLookupNutrition_image_callsVisionEndpoint` — mock session verifies round-trip
- [x] `testLookupNutrition_image_validResponse_returnsNutritionFacts` — mock JSON decoded correctly
- [ ] Manual: photo of apple returns nutrition facts from GPT-4o vision
- [ ] Manual: photo of printed nutrition label returns extracted normalized values

🤖 Generated with [Claude Code](https://claude.com/claude-code)